### PR TITLE
Added support for git accept_hostkey parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ The home directory where dotfiles will be linked. Generally, the default should 
 
 Which files from the dotfiles repository should be linked to the `dotfiles_home`.
 
+Add the hostkey for the repo url if not already added. If ssh_opts contains "-o StrictHostKeyChecking=no", this parameter is ignored. Defaults to `No`
+
+    dotfiles_repo_accept_hostkey: yes
+
 ## Dependencies
 
 None

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   git:
     repo: "{{ dotfiles_repo }}"
     dest: "{{ dotfiles_repo_local_destination }}"
+    accept_hostkey: "{{ dotfiles_repo_accept_hostkey | default(omit) }}"
   sudo: no
 
 - name: Ensure all configured dotfiles are links.


### PR DESCRIPTION
This adds support for git modules parameter accept_hostkey with a variable `dotfiles_repo_accept_hostkey`.
This is useful when setting up new nodes which haven't yet connected to the repo host. 

i used the filter `default(omit)` to make it default to the module default if unset because i didn't want to add defaults to the play. not entirely sure thats the right way.
