### PR TITLE
Updated environment values to use full variable syntax.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,14 +11,14 @@
   failed_when: false
   always_run: yes
   changed_when: false
-  with_items: dotfiles_files
+  with_items: "{{ dotfiles_files }}"
 
 - name: Remove existing dotfiles file if a replacement is being linked.
   file:
     path: "{{ dotfiles_home }}/{{ dotfiles_files[item.0] }}"
     state: absent
   when: "'@' not in item.1.stdout"
-  with_indexed_items: existing_dotfile_info.results
+  with_indexed_items: "{{ existing_dotfile_info.results }}"
 
 - name: Link dotfiles into home folder.
   file:
@@ -26,4 +26,4 @@
     dest: "{{ dotfiles_home }}/{{ item }}"
     state: link
   sudo: no
-  with_items: dotfiles_files
+  with_items: "{{ dotfiles_files }}"


### PR DESCRIPTION
I was getting deprecation warnings with Ansible 2.0.1 that the environment values needed to be contained with quotes and curly brackets, so added the necessary syntax.

Tested in 2.0.1 and 1.9.4, on Debian Jessie and Ubuntu 14.04.
