### PR TITLE
always_run is deprecated in Ansible 2.4

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
   shell: "ls -F {{ dotfiles_home }}/{{ item }}"
   register: existing_dotfile_info
   failed_when: false
-  always_run: yes
+  check_mode: no
   changed_when: false
   with_items: "{{ dotfiles_files }}"
 


### PR DESCRIPTION
As per #8, remove `always_run: yes`, and replace with `check_mode: no`. Note that `check_mode` requires Ansible 2.2.