### PR TITLE
Allow directory trees in dotfiles lists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,13 @@
   when: "'@' not in item.1.stdout"
   with_indexed_items: "{{ existing_dotfile_info.results }}"
 
+- name: Ensure parent folders of link dotfiles exist.
+  file:
+    path: "{{ (dotfiles_home ~ '/' ~ item) | dirname }}"
+    state: directory
+    follow: yes
+  with_items: "{{ dotfiles_files }}"
+
 - name: Link dotfiles into home folder.
   file:
     src: "{{ dotfiles_repo_local_destination }}/{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
     path: "{{ (dotfiles_home ~ '/' ~ item) | dirname }}"
     state: directory
     follow: yes
+  become: no  
   with_items: "{{ dotfiles_files }}"
 
 - name: Link dotfiles into home folder.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
   file:
     path: "{{ (dotfiles_home ~ '/' ~ item) | dirname }}"
     state: directory
-    follow: yes
+    follow: true
   become: no  
   with_items: "{{ dotfiles_files }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
     path: "{{ (dotfiles_home ~ '/' ~ item) | dirname }}"
     state: directory
     follow: true
-  become: no  
+  become: false
   with_items: "{{ dotfiles_files }}"
 
 - name: Link dotfiles into home folder.


### PR DESCRIPTION
Consider a directory tree layout in dotfiles layout like this:

```
dotfiles_files:
  - .gitconfig
  - .gitignore_global
  - .ssh/config
```

The current codebase supports this in a fairly straightforward manner, except it doesn't create parent directories like `.ssh` 

This PR fixes that by adding a play that creates parent directories. 