### PR TITLE
Add dotfiles_repo_clone_recursive option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The git repository to use for retrieving dotfiles. Dotfiles should generally be 
 
 Add the hostkey for the repo url if not already added. If ssh_opts contains "-o StrictHostKeyChecking=no", this parameter is ignored.
 
+    dotfiles_repo_clone_recursive: no
+
+Controls the `recursive` flag when cloning the dotfiles. If your dotfiles relies on [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules), set this variable to `yes`.
+
     dotfiles_repo_local_destination: "~/Documents/dotfiles"
 
 The local path where the `dotfiles_repo` will be cloned.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 dotfiles_repo: "https://github.com/geerlingguy/dotfiles.git"
 dotfiles_repo_accept_hostkey: no
+dotfiles_repo_clone_recursive: no
 dotfiles_repo_local_destination: "~/Documents/dotfiles"
 
 dotfiles_home: "~"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
     repo: "{{ dotfiles_repo }}"
     dest: "{{ dotfiles_repo_local_destination }}"
     accept_hostkey: "{{ dotfiles_repo_accept_hostkey }}"
+    recursive: "{{ dotfiles_repo_clone_recursive }}"
   become: no
 
 - name: Ensure all configured dotfiles are links.


### PR DESCRIPTION
My dotfiles rely on git submodules, so for my dotfiles to be properly bootstrapped, I need to clone the submodules as well. The option introduced here defaults to `no`, so existing users will not be impacted.