### PR TITLE
fix: Set permissions in a way that does not break directories

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,6 @@
     src: "{{ dotfiles_repo_local_destination }}/{{ item }}"
     dest: "{{ dotfiles_home }}/{{ item }}"
     state: link
-    mode: 0644
+    mode: "u=rwX,g=rX,o=rX"
   become: false
   with_items: "{{ dotfiles_files }}"


### PR DESCRIPTION
Current 0644 permissions break directories (e.g. `.vim`), so use symbolic mode to set 0755 for directories and 0644 for files.