### PR TITLE
Show filename while looping over task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,8 @@
     state: absent
   when: "'@' not in item.1.stdout"
   with_indexed_items: "{{ existing_dotfile_info.results }}"
+  loop_control:
+    label: "{{ dotfiles_files[item.0] }}"
 
 - name: Link dotfiles into home folder.
   file:


### PR DESCRIPTION
Currently, 'Remove existing dotfiles file if a replacement is being linked.' prints a huge dictionary as label when looping over files. This patch changes the label to filename.