### PR TITLE
Fix issue with space in dotfile filename or path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   become: false
 
 - name: Ensure all configured dotfiles are links.
-  command: "ls -F {{ dotfiles_home }}/{{ item }}"
+  command: "ls -F {{ dotfiles_home }}/'{{ item }}'"
   register: existing_dotfile_info
   failed_when: false
   check_mode: false


### PR DESCRIPTION
Fixes an issue where if a dotfile has a space in the filename or path the "Ensure all configured dotfiles are links." task reports "No such file or directory" even when the file exists as it treats it as multiple separate paths.

Broken Example:

```bash
# ls -F ~/test folder/testfile.txt
ls: /Users/username/test: No such file or directory
ls: folder/testfile.txt: No such file or directory
```

Fixed Example:
```bash
# ls -F ~/'test folder/testfile.txt'
/Users/username/test folder/testfile.txt@
```