### PR TITLE
Keep file mode intact

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,5 @@
     src: "{{ dotfiles_repo_local_destination }}/{{ item }}"
     dest: "{{ dotfiles_home }}/{{ item }}"
     state: link
-    mode: 0644
   become: false
   with_items: "{{ dotfiles_files }}"


### PR DESCRIPTION
Fixes geerlingguy/mac-dev-playbook#212. Overriding the file mode on the symlink drops the executable flag on e.g. `.osx`.