### PR TITLE
add 'dotfiles_add_dot_prefix' option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: pip3 install ansible molecule molecule-plugins[docker] docker
 
       - name: Run Molecule tests.
-        run: molecule test
+        run: molecule test --all
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ The home directory where dotfiles will be linked. Generally, the default should 
 
 Which files from the dotfiles repository should be linked to the `dotfiles_home`.
 
+    dotfiles_add_dot_prefix: false
+
+Whether to add a dot to dotfiles symbolic links. This is useful if you store your dotfiles without "." prefix in
+your source repository.
+
 ## Dependencies
 
 None

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ dotfiles_files:
   - .gitignore
   - .inputrc
   - .vimrc
+
+dotfiles_add_dot_prefix: false

--- a/molecule/add_dot_prefix/converge.yml
+++ b/molecule/add_dot_prefix/converge.yml
@@ -1,0 +1,20 @@
+---
+- name: Converge
+  hosts: all
+  #become: true
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt:
+        update_cache: true
+        cache_valid_time: 600
+      when: ansible_facts.os_family == 'Debian'
+
+  roles:
+    - role: geerlingguy.git
+    - role: geerlingguy.dotfiles
+      dotfiles_repo: https://github.com/egdoc/dotfiles.git
+      dotfiles_files:
+        - bash_profile
+        - bashrc
+      dotfiles_add_dot_prefix: true

--- a/molecule/add_dot_prefix/molecule.yml
+++ b/molecule/add_dot_prefix/molecule.yml
@@ -1,0 +1,21 @@
+---
+role_name_check: 1
+dependency:
+  name: galaxy
+  options:
+    ignore-errors: true
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-rockylinux9}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}

--- a/molecule/add_dot_prefix/requirements.yml
+++ b/molecule/add_dot_prefix/requirements.yml
@@ -1,0 +1,2 @@
+---
+- src: geerlingguy.git

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   become: false
 
 - name: Ensure all configured dotfiles are links.
-  command: "ls -F {{ dotfiles_home }}/{{ item }}"
+  command: "ls -F {{ dotfiles_home }}/{{ '.' ~ item if dotfiles_add_dot_prefix else item }}"
   register: existing_dotfile_info
   failed_when: false
   check_mode: false
@@ -17,7 +17,7 @@
 
 - name: Remove existing dotfiles file if a replacement is being linked.
   file:
-    path: "{{ dotfiles_home }}/{{ dotfiles_files[item.0] }}"
+    path: "{{ dotfiles_home }}/{{ '.' ~ dotfiles_files[item.0] if dotfiles_add_dot_prefix else dotfiles_files[item.0] }}"
     state: absent
   when: "'@' not in item.1.stdout"
   with_indexed_items: "{{ existing_dotfile_info.results }}"
@@ -33,7 +33,7 @@
 - name: Link dotfiles into home folder.
   file:
     src: "{{ dotfiles_repo_local_destination }}/{{ item }}"
-    dest: "{{ dotfiles_home }}/{{ item }}"
+    dest: "{{ dotfiles_home }}/{{ '.' ~ item if dotfiles_add_dot_prefix else item }}"
     state: link
   become: false
   with_items: "{{ dotfiles_files }}"


### PR DESCRIPTION
This change allows storing dotfiles in a github repository as standard files, so they are always visible when the repository is cloned. When setting the `dotfiles_add_dot_prefix` option to `true`, the dot is dynamically prepended to the symbolic link name. 